### PR TITLE
feature: bring pcs back to subroutines.

### DIFF
--- a/subroutines/src/lib.rs
+++ b/subroutines/src/lib.rs
@@ -6,8 +6,8 @@
 
 #![allow(clippy::non_canonical_clone_impl)] // using `derivative`
 
-// pub mod pcs;
+pub mod pcs;
 pub mod poly_iop;
 
-// pub use pcs::prelude::*;
+pub use pcs::prelude::*;
 pub use poly_iop::prelude::*;

--- a/subroutines/src/pcs/mod.rs
+++ b/subroutines/src/pcs/mod.rs
@@ -7,7 +7,7 @@
 mod errors;
 mod multilinear_kzg;
 mod structs;
-mod univariate_kzg;
+// mod univariate_kzg;
 
 pub mod prelude;
 

--- a/subroutines/src/pcs/multilinear_kzg/batching.rs
+++ b/subroutines/src/pcs/multilinear_kzg/batching.rs
@@ -287,7 +287,7 @@ mod tests {
     use arithmetic::get_batched_nv;
     use ark_bls12_381::Bls12_381 as E;
     use ark_ec::pairing::Pairing;
-    use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+    use ark_poly::{DenseMultilinearExtension, MultilinearExtension, Polynomial};
     use ark_std::{rand::Rng, test_rng, vec::Vec, UniformRand};
 
     type Fr = <E as Pairing>::ScalarField;
@@ -311,7 +311,7 @@ mod tests {
         let evals = polys
             .iter()
             .zip(points.iter())
-            .map(|(f, p)| f.evaluate(p).unwrap())
+            .map(|(f, p)| f.evaluate(p))
             .collect::<Vec<_>>();
 
         let commitments = polys

--- a/subroutines/src/pcs/prelude.rs
+++ b/subroutines/src/pcs/prelude.rs
@@ -13,9 +13,9 @@ pub use crate::pcs::{
         MultilinearKzgPCS, MultilinearKzgProof,
     },
     structs::Commitment,
-    univariate_kzg::{
-        srs::{UnivariateProverParam, UnivariateUniversalParams, UnivariateVerifierParam},
-        UnivariateKzgBatchProof, UnivariateKzgPCS, UnivariateKzgProof,
-    },
+    // univariate_kzg::{
+    //     srs::{UnivariateProverParam, UnivariateUniversalParams, UnivariateVerifierParam},
+    //     UnivariateKzgBatchProof, UnivariateKzgPCS, UnivariateKzgProof,
+    // },
     PolynomialCommitmentScheme, StructuredReferenceString,
 };


### PR DESCRIPTION
### This PR:
* MultilinearKZG is now available.
  * compatible with arkworks`0.5.0` 

### This PR does not:
* UnivariateKZG is still inactive.

### Key places to review:
Legacy MSM has been refactored in the original hyperplonk repository by adding BatchMulPreProcessing structure and corresponding functions.

[Update history in ark-ec](https://github.com/arkworks-rs/algebra/pull/746/commits/9b1655d998c6b21caf82c9bff5632b8bcb3b7fd5)

```bash
cd subroutines
cargo test --release
```
the script should be passed.

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
